### PR TITLE
BTE world type as a shortcut when creating a terra world for BTE

### DIFF
--- a/src/main/java/io/github/terra121/BTEWorldType.java
+++ b/src/main/java/io/github/terra121/BTEWorldType.java
@@ -1,0 +1,62 @@
+package io.github.terra121;
+
+
+import net.minecraft.client.gui.GuiCreateWorld;
+import net.minecraft.world.WorldType;
+import net.minecraftforge.client.event.GuiScreenEvent;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public class BTEWorldType extends EarthWorldType {
+
+	private static final String BTE_GENERATOR_SETTINGS = "{\"projection\":\"bteairocean\",\"orentation\":\"upright\",\"scaleX\":7318261.522857145,\"scaleY\":7318261.522857145,\"smoothblend\":true,\"roads\":true,\"customcubic\":\"\",\"dynamicbaseheight\":true,\"osmwater\":true,\"buildings\":true}";
+
+	public static BTEWorldType create() {
+		return new BTEWorldType();
+	}
+
+	@SubscribeEvent
+	@SideOnly(Side.CLIENT)
+	public static void onGuiActionPerformedPre(GuiScreenEvent.ActionPerformedEvent.Pre event) {
+		if(event.getGui() instanceof GuiCreateWorld) {
+			GuiCreateWorld screen = (GuiCreateWorld) event.getGui();
+			if(event.getButton().id == 0) { //This is the create world button
+				
+				//Get the selected world type index
+				//The absence of any error handling here is voluntary,
+				//we'd rather crash than let users create worlds with the wrong settings without them knowing
+				int selectedIndex = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, screen, "field_146331_K");
+				
+				if(WorldType.WORLD_TYPES[selectedIndex] instanceof BTEWorldType) {
+					screen.chunkProviderSettingsJson = BTE_GENERATOR_SETTINGS;
+				}
+			}
+		}
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public String getTranslationKey() {
+		return "generator.bte";
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public String getInfoTranslationKey() {
+		return "generator.bte.info";
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public boolean hasInfoNotice() {
+		return true;
+	}
+
+	@Override
+	public boolean isCustomizable() {
+		return false;
+	}
+
+}

--- a/src/main/java/io/github/terra121/EarthWorldType.java
+++ b/src/main/java/io/github/terra121/EarthWorldType.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class EarthWorldType extends WorldType implements ICubicWorldType {
+	
     public static EarthWorldType create() {
         return new EarthWorldType();
     }

--- a/src/main/java/io/github/terra121/TerraMod.java
+++ b/src/main/java/io/github/terra121/TerraMod.java
@@ -1,5 +1,7 @@
 package io.github.terra121;
 
+import org.apache.logging.log4j.Logger;
+
 import io.github.terra121.control.TerraAdminCommand;
 import io.github.terra121.control.TerraCommand;
 import io.github.terra121.control.TerraTeleport;
@@ -8,8 +10,6 @@ import io.github.terra121.letsencryptcraft.LetsEncryptAdder;
 import io.github.terra121.provider.EarthWorldProvider;
 import io.github.terra121.provider.GenerationEventDenier;
 import io.github.terra121.provider.WaterDenier;
-import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.DimensionType;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
@@ -20,9 +20,9 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.server.permission.DefaultPermissionLevel;
 import net.minecraftforge.server.permission.PermissionAPI;
-import org.apache.logging.log4j.Logger;
 
 @Mod(modid = TerraMod.MODID, name = TerraMod.NAME, version = TerraMod.VERSION, dependencies = "required-after:cubicchunks; required-after:cubicgen", acceptableRemoteVersions = "*")
 public class TerraMod implements ILetsEncryptMod {
@@ -46,6 +46,10 @@ public class TerraMod implements ILetsEncryptMod {
     public void preInit(FMLPreInitializationEvent event) {
         LOGGER = event.getModLog();
         EarthWorldType.create();
+        
+        // This is just a handy shortcut when creating new BTE worlds on the client not needed on the server
+        // It is critical that this happens after the EarthWorldType is registered
+        if(Side.CLIENT.equals(event.getSide())) BTEWorldType.create();
 
         if (CUSTOM_PROVIDER) {
             setupProvider();
@@ -57,6 +61,7 @@ public class TerraMod implements ILetsEncryptMod {
         MinecraftForge.TERRAIN_GEN_BUS.register(GenerationEventDenier.class);
         MinecraftForge.EVENT_BUS.register(WaterDenier.class);
         MinecraftForge.EVENT_BUS.register(TerraConfig.class);
+        if(Side.CLIENT.equals(event.getSide())) MinecraftForge.EVENT_BUS.register(BTEWorldType.class);
         PermissionAPI.registerNode(TerraConstants.controlCommandNode + "tpll", DefaultPermissionLevel.OP, "Allows a player to do /tpll");
         PermissionAPI.registerNode(TerraConstants.controlCommandNode + "terra", DefaultPermissionLevel.OP, "Allows access to terra commands");
         PermissionAPI.registerNode(TerraConstants.controlCommandNode + "terra.utility", DefaultPermissionLevel.OP, "Allows access to terra++'s utilities");

--- a/src/main/resources/assets/terra121/lang/en_us.lang
+++ b/src/main/resources/assets/terra121/lang/en_us.lang
@@ -1,5 +1,7 @@
 ## World Type name
 generator.EarthCubic=Planet Earth
+generator.bte=Build the Earth
+generator.bte.info=Planet Earth world with the default Build the Earth settings
 
 ## GUI options
 terra121.gui.projection=Projection


### PR DESCRIPTION
The idea is just to add a `Build the Earth` option in the create world menu that creates an `EarthCubic` world with the BTE settings.

I'm not super happy about the implementation, but couldn't find a better way. Maybe someone has a better idea? If not I'll pull it like that.