### PR TITLE
Throw OutOfProjectionBounds in Mercator projections, more coherent projection class names

### DIFF
--- a/src/main/java/io/github/terra121/config/GlobalParseRegistries.java
+++ b/src/main/java/io/github/terra121/config/GlobalParseRegistries.java
@@ -27,15 +27,15 @@ import io.github.terra121.config.scalarparse.i.RequireOpaqueISP;
 import io.github.terra121.config.scalarparse.i.SwapAxesISP;
 import io.github.terra121.config.scalarparse.i.FlipZISP;
 import io.github.terra121.projection.mercator.CenteredMercatorProjection;
-import io.github.terra121.projection.EqualEarth;
+import io.github.terra121.projection.EqualEarthProjection;
 import io.github.terra121.projection.EquirectangularProjection;
 import io.github.terra121.projection.GeographicProjection;
 import io.github.terra121.projection.SinusoidalProjection;
 import io.github.terra121.projection.mercator.WebMercatorProjection;
 import io.github.terra121.projection.mercator.TransverseMercatorProjection;
-import io.github.terra121.projection.dymaxion.Dymaxion;
-import io.github.terra121.projection.dymaxion.ConformalEstimate;
-import io.github.terra121.projection.dymaxion.BTEDymaxion;
+import io.github.terra121.projection.dymaxion.DymaxionProjection;
+import io.github.terra121.projection.dymaxion.ConformalDynmaxionProjection;
+import io.github.terra121.projection.dymaxion.BTEDymaxionProjection;
 import io.github.terra121.projection.transform.FlipHorizontalProjectionTransform;
 import io.github.terra121.projection.transform.FlipVerticalProjectionTransform;
 import io.github.terra121.projection.transform.OffsetProjectionTransform;
@@ -61,10 +61,10 @@ public class GlobalParseRegistries {
             .put("transverse_mercator", TransverseMercatorProjection.class)
             .put("equirectangular", EquirectangularProjection.class)
             .put("sinusoidal", SinusoidalProjection.class)
-            .put("equal_earth", EqualEarth.class)
-            .put("bte_conformal_dymaxion", BTEDymaxion.class)
-            .put("dymaxion", Dymaxion.class)
-            .put("conformal_dymaxion", ConformalEstimate.class)
+            .put("equal_earth", EqualEarthProjection.class)
+            .put("bte_conformal_dymaxion", BTEDymaxionProjection.class)
+            .put("dymaxion", DymaxionProjection.class)
+            .put("conformal_dymaxion", ConformalDynmaxionProjection.class)
             //transformations
             .put("flip_horizontal", FlipHorizontalProjectionTransform.class)
             .put("flip_vertical", FlipVerticalProjectionTransform.class)

--- a/src/main/java/io/github/terra121/dataset/builtin/Climate.java
+++ b/src/main/java/io/github/terra121/dataset/builtin/Climate.java
@@ -1,7 +1,7 @@
 package io.github.terra121.dataset.builtin;
 
 import io.github.terra121.dataset.BlendMode;
-import io.github.terra121.projection.dymaxion.ConformalEstimate;
+import io.github.terra121.projection.dymaxion.ConformalDynmaxionProjection;
 import io.github.terra121.util.IntToDoubleBiFunction;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -51,7 +51,7 @@ public class Climate {
     @SneakyThrows(IOException.class)
     public static void main(String... args) {
         Matcher matcher;
-        try (InputStream in = ConformalEstimate.class.getResourceAsStream("conformal.txt")) {
+        try (InputStream in = ConformalDynmaxionProjection.class.getResourceAsStream("conformal.txt")) {
             matcher = Pattern.compile("\\[(.*?), (.*?)]", Pattern.MULTILINE).matcher(new AsciiString(StreamUtil.toByteArray(in), false));
         }
 

--- a/src/main/java/io/github/terra121/projection/EqualEarthProjection.java
+++ b/src/main/java/io/github/terra121/projection/EqualEarthProjection.java
@@ -10,7 +10,7 @@ import io.github.terra121.util.MathUtils;
  * @see <a href="https://en.wikipedia.org/wiki/Equal_Earth_projection"> Wikipedia's article on the Equal Earth projection</a>
  */
 @JsonDeserialize
-public class EqualEarth implements GeographicProjection {
+public class EqualEarthProjection implements GeographicProjection {
     private static final double A1 = 1.340264;
     private static final double A2 = -0.081106;
     private static final double A3 = 0.000893;

--- a/src/main/java/io/github/terra121/projection/EquirectangularProjection.java
+++ b/src/main/java/io/github/terra121/projection/EquirectangularProjection.java
@@ -2,8 +2,6 @@ package io.github.terra121.projection;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import static java.lang.Math.*;
-
 /**
  * Implements the equirectangular map projection, which applies no transformation at all.
  * x and y are therefore the same as longitude and latitude (in degrees).
@@ -20,7 +18,7 @@ public class EquirectangularProjection implements GeographicProjection {
      */
     @Override
 	public double[] toGeo(double x, double y) throws OutOfProjectionBoundsException {
-        this.checkArgs(x, y);
+    	OutOfProjectionBoundsException.checkLongitudeLatitudeInRange(x, y);
         return new double[]{ x, y };
     }
 
@@ -34,7 +32,7 @@ public class EquirectangularProjection implements GeographicProjection {
      */
     @Override
 	public double[] fromGeo(double longitude, double latitude) throws OutOfProjectionBoundsException {
-        this.checkArgs(longitude, latitude);
+        OutOfProjectionBoundsException.checkLongitudeLatitudeInRange(longitude, latitude);
         return new double[]{ longitude, latitude };
     }
 
@@ -48,12 +46,6 @@ public class EquirectangularProjection implements GeographicProjection {
     @Override
 	public double metersPerUnit() {
         return 100000;
-    }
-
-    protected void checkArgs(double lon, double lat) throws OutOfProjectionBoundsException {
-        if (abs(lon) > 180.0d || abs(lat) > 90.0d) {
-            throw OutOfProjectionBoundsException.get();
-        }
     }
 
     @Override

--- a/src/main/java/io/github/terra121/projection/OutOfProjectionBoundsException.java
+++ b/src/main/java/io/github/terra121/projection/OutOfProjectionBoundsException.java
@@ -16,4 +16,26 @@ public final class OutOfProjectionBoundsException extends Exception {
     private OutOfProjectionBoundsException(boolean flag) {
         super(null, null, flag, flag);
     }
+    
+    /**
+     * 
+     * @param x
+     * @param y
+     * @param maxX
+     * @param maxY
+     * @throws OutOfProjectionBoundsException if <code> Math.abs(x) > maxX || Math.abs(y) > maxY </code>
+     */
+    public static void checkInRange(double x, double y, double maxX, double maxY) throws OutOfProjectionBoundsException {
+    	if(Math.abs(x) > maxX || Math.abs(y) > maxY) throw OutOfProjectionBoundsException.get();
+    }
+    
+    /**
+     * 
+     * @param longitude
+     * @param latitude
+     * @throws OutOfProjectionBoundsException if <code> Math.abs(longitude) > 180 || Math.abs(latitude) > 90 </code>
+     */
+    public static void checkLongitudeLatitudeInRange(double longitude, double latitude) throws OutOfProjectionBoundsException {
+    	checkInRange(longitude, latitude, 180, 90);
+    }
 }

--- a/src/main/java/io/github/terra121/projection/dymaxion/BTEDymaxionProjection.java
+++ b/src/main/java/io/github/terra121/projection/dymaxion/BTEDymaxionProjection.java
@@ -7,11 +7,11 @@ import io.github.terra121.util.MathUtils;
 /**
  * Implementation of the BTE modified Dynmaxion projection.
  * 
- * @see Dymaxion
- * @see io.github.terra121.projection.dymaxion.ConformalEstimate
+ * @see DymaxionProjection
+ * @see io.github.terra121.projection.dymaxion.ConformalDynmaxionProjection
  */
 @JsonDeserialize
-public class BTEDymaxion extends ConformalEstimate {
+public class BTEDymaxionProjection extends ConformalDynmaxionProjection {
 
     protected static final double THETA = Math.toRadians(-150);
     protected static final double SIN_THETA = Math.sin(THETA);

--- a/src/main/java/io/github/terra121/projection/dymaxion/ConformalDynmaxionProjection.java
+++ b/src/main/java/io/github/terra121/projection/dymaxion/ConformalDynmaxionProjection.java
@@ -16,12 +16,12 @@ import net.daporkchop.lib.common.util.PArrays;
 
 /**
  * Implementation of the Dynmaxion like conformal projection.
- * Slightly modifies the Dynmaxion projection to make it conformal.
+ * Slightly modifies the Dynmaxion projection to make it (almost) conformal.
  *
- * @see Dymaxion
+ * @see DymaxionProjection
  */
 @JsonDeserialize
-public class ConformalEstimate extends Dymaxion {
+public class ConformalDynmaxionProjection extends DymaxionProjection {
     protected static final double VECTOR_SCALE_FACTOR = 1.0d / 1.1473979730192934d;
     protected static final int SIDE_LENGTH = 256;
 
@@ -30,7 +30,7 @@ public class ConformalEstimate extends Dymaxion {
         double[][] vy = PArrays.filled(SIDE_LENGTH + 1, double[][]::new, i -> new double[SIDE_LENGTH + 1 - i]);
 
         ByteBuf buf;
-        try (InputStream in = new BZip2CompressorInputStream(ConformalEstimate.class.getResourceAsStream("conformal.bz2"))) {
+        try (InputStream in = new BZip2CompressorInputStream(ConformalDynmaxionProjection.class.getResourceAsStream("conformal.bz2"))) {
             buf = Unpooled.wrappedBuffer(StreamUtil.toByteArray(in));
         }
 

--- a/src/main/java/io/github/terra121/projection/dymaxion/ConformalEstimate.java
+++ b/src/main/java/io/github/terra121/projection/dymaxion/ConformalEstimate.java
@@ -1,21 +1,18 @@
 package io.github.terra121.projection.dymaxion;
 
+import java.io.InputStream;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import io.github.terra121.util.MathUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.AsciiString;
 import net.daporkchop.lib.binary.oio.StreamUtil;
 import net.daporkchop.lib.common.function.io.IOSupplier;
 import net.daporkchop.lib.common.ref.Ref;
 import net.daporkchop.lib.common.util.PArrays;
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
-
-import java.io.InputStream;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static net.daporkchop.lib.common.util.PValidation.*;
 
 /**
  * Implementation of the Dynmaxion like conformal projection.

--- a/src/main/java/io/github/terra121/projection/dymaxion/DymaxionProjection.java
+++ b/src/main/java/io/github/terra121/projection/dymaxion/DymaxionProjection.java
@@ -12,7 +12,7 @@ import io.github.terra121.util.MathUtils;
  * @see <a href="https://en.wikipedia.org/wiki/Dymaxion_map">Wikipedia's article on the Dynmaxion projection</a>
  */
 @JsonDeserialize
-public class Dymaxion implements GeographicProjection {
+public class DymaxionProjection implements GeographicProjection {
 
     protected static final double ARC = 2 * Math.asin(Math.sqrt(5 - Math.sqrt(5)) / Math.sqrt(10));
     protected static final double Z = Math.sqrt(5 + 2 * Math.sqrt(5)) / Math.sqrt(15);

--- a/src/main/java/io/github/terra121/projection/mercator/CenteredMercatorProjection.java
+++ b/src/main/java/io/github/terra121/projection/mercator/CenteredMercatorProjection.java
@@ -3,6 +3,7 @@ package io.github.terra121.projection.mercator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.github.terra121.TerraConstants;
 import io.github.terra121.projection.GeographicProjection;
+import io.github.terra121.projection.OutOfProjectionBoundsException;
 
 /**
  * Implementation of the Mercator projection, normalized between -1 and 1.
@@ -14,7 +15,8 @@ import io.github.terra121.projection.GeographicProjection;
 public class CenteredMercatorProjection implements GeographicProjection {
 
     @Override
-    public double[] toGeo(double x, double y) {
+    public double[] toGeo(double x, double y) throws OutOfProjectionBoundsException {
+    	OutOfProjectionBoundsException.checkInRange(x, y, 1, 1);
         return new double[]{
                 x * 180.0,
                 Math.toDegrees(Math.atan(Math.exp(-y * Math.PI)) * 2 - Math.PI / 2)
@@ -22,7 +24,8 @@ public class CenteredMercatorProjection implements GeographicProjection {
     }
 
     @Override
-    public double[] fromGeo(double longitude, double latitude) {
+    public double[] fromGeo(double longitude, double latitude) throws OutOfProjectionBoundsException {
+    	OutOfProjectionBoundsException.checkInRange(longitude, latitude, 180, WebMercatorProjection.LIMIT_LATITUDE);
         return new double[]{
                 longitude / 180.0,
                 -(Math.log(Math.tan((Math.PI / 2 + Math.toRadians(latitude)) / 2))) / Math.PI

--- a/src/main/java/io/github/terra121/projection/mercator/TransverseMercatorProjection.java
+++ b/src/main/java/io/github/terra121/projection/mercator/TransverseMercatorProjection.java
@@ -3,6 +3,7 @@ package io.github.terra121.projection.mercator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.github.terra121.TerraConstants;
 import io.github.terra121.projection.GeographicProjection;
+import io.github.terra121.projection.OutOfProjectionBoundsException;
 
 /**
  * Implementation of the universal transverse Mercator projection.
@@ -31,7 +32,8 @@ public class TransverseMercatorProjection implements GeographicProjection {
     }
 
     @Override
-    public double[] fromGeo(double longitude, double latitude) {
+    public double[] fromGeo(double longitude, double latitude) throws OutOfProjectionBoundsException {
+    	OutOfProjectionBoundsException.checkLongitudeLatitudeInRange(longitude, latitude);
         double lam = Math.toRadians(longitude);
         double phi = Math.toRadians(latitude);
         double centralMeridian = getCentralMeridian(lam);
@@ -45,7 +47,8 @@ public class TransverseMercatorProjection implements GeographicProjection {
     }
 
     @Override
-    public double[] toGeo(double x, double y) {
+    public double[] toGeo(double x, double y) throws OutOfProjectionBoundsException {
+    	OutOfProjectionBoundsException.checkInRange(x, y, Math.PI, Math.PI/2);
         double centralMeridian = getCentralMeridian(x);
         x -= centralMeridian;
         double lam = Math.atan2(Math.sinh(x), Math.cos(y)) + centralMeridian;


### PR DESCRIPTION
Adds checks in `GeographicProjection#toGeo(long, long)` and `GeographicProjection#fromGeo(long, long)` implementations in Mercator and equal earth projections.
Changes projection classes name to match the `WhateverProjection` scheme.