### PR TITLE
Ignorecase on Telport Command

### DIFF
--- a/src/main/java/net/buildtheearth/terraplusplus/control/Command.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/control/Command.java
@@ -10,7 +10,7 @@ import net.minecraftforge.server.permission.PermissionAPI;
 public abstract class Command extends CommandBase {
 
     public Command() {
-        PermissionAPI.registerNode(TerraConstants.defaultCommandNode + this.getName(), DefaultPermissionLevel.OP, "");
+        PermissionAPI.registerNode(TerraConstants.defaultCommandNode + this.toLowerCase().getName(), DefaultPermissionLevel.OP, "");
     }
 
     protected boolean hasPermission(ICommandSender sender, String perm) {


### PR DESCRIPTION
I am on holiday, which is why I cannot check my changes. But I have heard that it bothers some that /tpll is case sensetive. I figured it would be easy to just make the input lowercase. If that doesn't work I apologise and would be happy if someone else could fix it. 
Kind regards