### PR TITLE
Fix single digit coordinate parsing

### DIFF
--- a/src/main/java/net/buildtheearth/terraplusplus/util/geo/CoordinateParseUtils.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/util/geo/CoordinateParseUtils.java
@@ -1,11 +1,12 @@
 package net.buildtheearth.terraplusplus.util.geo;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 
 /**
  * Utilities for assisting in the parsing of latitude and longitude strings into Decimals.
@@ -66,7 +67,7 @@ public class CoordinateParseUtils {
                 return null;
             }
 
-        } else if (coordinates.length() > 4) {
+        } else if (coordinates.length() > 2) {
             // try to split and then use lat/lon parsing
             for (final char delim : ",;/ ".toCharArray()) {
                 int cnt = StringUtils.countMatches(coordinates, String.valueOf(delim));
@@ -101,8 +102,6 @@ public class CoordinateParseUtils {
     }
 
     private static LatLng validateAndRound(double lat, double lon) {
-        final double latOrig = lat;
-        final double lngOrig = lon;
         lat = roundTo6decimals(lat);
         lon = roundTo6decimals(lon);
 

--- a/src/test/java/net/buildtheearth/terraplusplus/util/OrderedRegistryTest.java
+++ b/src/test/java/net/buildtheearth/terraplusplus/util/OrderedRegistryTest.java
@@ -1,11 +1,12 @@
-import net.buildtheearth.terraplusplus.util.OrderedRegistry;
-import org.junit.Test;
+package net.buildtheearth.terraplusplus.util;
+
+import static net.daporkchop.lib.common.util.PValidation.checkState;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static net.daporkchop.lib.common.util.PValidation.*;
+import org.junit.Test;
 
 /**
  * @author DaPorkchop_

--- a/src/test/java/net/buildtheearth/terraplusplus/util/geo/CoordinateParseUtilsTest.java
+++ b/src/test/java/net/buildtheearth/terraplusplus/util/geo/CoordinateParseUtilsTest.java
@@ -1,0 +1,48 @@
+package net.buildtheearth.terraplusplus.util.geo;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * @author SmylerMC
+ */
+public class CoordinateParseUtilsTest {
+    
+    private static final double PRECISION = 1e-7;
+    
+    @Test
+    public void test() {
+        this.testValidStringParsing("02°49'52\"N131°47'03\"E", 131.784167, 2.831111);
+        this.testValidStringParsing("02°49'52''N 131°47'03''E", 131.784167, 2.831111);
+        this.testValidStringParsing("02°49'52\"n 131°47'03\"E", 131.784167, 2.831111);
+        this.testValidStringParsing("02°49'52\"N 131°47'03\"e", 131.784167, 2.831111);
+        this.testValidStringParsing("02°49'52\"S 131°47'03\"E", 131.784167, -2.831111);
+        this.testValidStringParsing("02°49'52\"N 131°47'03\"W", -131.784167, 2.831111);
+        this.testValidStringParsing("02°49'52\"s 131°47'03\"w", -131.784167, -2.831111);
+        this.testValidStringParsing("2.831111s 131.784167w", -131.784167, -2.831111);
+        this.testValidStringParsing("-2.831111 -131.784167", -131.784167, -2.831111);
+        
+        this.testValidStringParsing("02°49'52\"N;131°47'03\"E", 131.784167, 2.831111);
+        this.testValidStringParsing("2.831111s;131.784167w", -131.784167, -2.831111);
+        this.testValidStringParsing("-2.831111;-131.784167", -131.784167, -2.831111);
+        this.testValidStringParsing("02°49'52\"N,131°47'03\"E", 131.784167, 2.831111);
+        this.testValidStringParsing("2.831111s,131.784167w", -131.784167, -2.831111);
+        this.testValidStringParsing("-2.831111,-131.784167", -131.784167, -2.831111);
+        
+        this.testValidStringParsing("2 131", 131, 2);
+        this.testValidStringParsing("-2 -131", -131, -2);
+        this.testValidStringParsing("0. 0.", 0, 0);
+        this.testValidStringParsing("0 0", 0, 0);
+        this.testValidStringParsing("0.1 0", 0, 0.1);
+    }
+    
+    private void testValidStringParsing(String string, double longitude, double latitude) {
+        LatLng latLng = CoordinateParseUtils.parseVerbatimCoordinates(string);
+        Assert.assertNotNull(String.format("Failed to parse a valid coordinate string: %s", string), latLng);
+        final double lng = latLng.getLng();
+        final double lat = latLng.getLat();
+        Assert.assertEquals("Parsed a wrong longitude value", longitude, lng, PRECISION);
+        Assert.assertEquals("Parsed a wrong latitude value", latitude, lat, PRECISION);
+    }
+
+}


### PR DESCRIPTION
Fixed single digit coordinates not being parsed properly (e.g. `/tpll 0 0` would fail).
Do not use the default package for tests.
Test unit for coordinate parsing.