### PR TITLE
Bump PorkLib to 0.5.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     shade "com.fasterxml.jackson.core:jackson-databind:2.11.2"
 
-    shade("net.daporkchop.lib:binary:0.5.5-SNAPSHOT")  {
+    shade("net.daporkchop.lib:binary:0.5.7-SNAPSHOT")  {
         exclude group: "io.netty"
     }
 

--- a/src/main/java/net/buildtheearth/terraplusplus/control/AdvancedEarthGui.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/control/AdvancedEarthGui.java
@@ -16,7 +16,8 @@ import net.buildtheearth.terraplusplus.projection.transform.ProjectionTransform;
 import net.buildtheearth.terraplusplus.projection.transform.RotateProjectionTransform;
 import net.buildtheearth.terraplusplus.projection.transform.ScaleProjectionTransform;
 import net.daporkchop.lib.common.function.io.IOSupplier;
-import net.daporkchop.lib.common.ref.Ref;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 import net.daporkchop.lib.common.util.PArrays;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -72,8 +73,9 @@ import static net.daporkchop.lib.common.util.PValidation.*;
 public class AdvancedEarthGui extends GuiScreen {
     protected static final int SRC_W = 2048;
     protected static final int SRC_H = 1024;
-    protected static final Ref<int[]> SRC_CACHE = Ref.soft((IOSupplier<int[]>) () ->
-            ImageIO.read(AdvancedEarthGui.class.getResource("map.png")).getRGB(0, 0, SRC_W, SRC_H, null, 0, SRC_W));
+    protected static final Cached<int[]> SRC_CACHE = Cached.global((IOSupplier<int[]>) () ->
+            ImageIO.read(AdvancedEarthGui.class.getResource("map.png")).getRGB(0, 0, SRC_W, SRC_H, null, 0, SRC_W),
+            ReferenceStrength.SOFT);
 
     protected static final int VERTICAL_PADDING = 32;
 
@@ -679,7 +681,7 @@ public class AdvancedEarthGui extends GuiScreen {
 
             public RootEntry(GeographicProjection projection, AdvancedEarthGui gui, int x, int y, int width) {
                 String projectionName = GlobalParseRegistries.PROJECTIONS.inverse().get(projection.getClass());
-                this.initialIndex = this.index = PArrays.indexOf(PROJECTION_NAMES, projectionName);
+                this.initialIndex = this.index = PArrays.linearSearch(PROJECTION_NAMES, projectionName);
 
                 this.button = gui.addButton(new EntryButton(x, y, width, I18n.format(this.fieldName = TerraConstants.MODID + ".gui.projection." + projectionName)) {
                     @Override

--- a/src/main/java/net/buildtheearth/terraplusplus/dataset/builtin/Climate.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/dataset/builtin/Climate.java
@@ -7,7 +7,8 @@ import net.buildtheearth.terraplusplus.dataset.BlendMode;
 import net.buildtheearth.terraplusplus.util.IntToDoubleBiFunction;
 import net.daporkchop.lib.binary.oio.StreamUtil;
 import net.daporkchop.lib.common.function.io.IOSupplier;
-import net.daporkchop.lib.common.ref.Ref;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 
 import java.io.InputStream;
 
@@ -15,7 +16,7 @@ public abstract class Climate extends AbstractBuiltinDataset implements IntToDou
     public static final int COLS = 720;
     public static final int ROWS = 360;
 
-    private static final Ref<double[]> DATA_CACHE = Ref.soft((IOSupplier<double[]>) () -> {
+    private static final Cached<double[]> DATA_CACHE = Cached.global((IOSupplier<double[]>) () -> {
         ByteBuf buf;
         try (InputStream in = new LzmaInputStream(Climate.class.getResourceAsStream("climate.lzma"))) {
             buf = Unpooled.wrappedBuffer(StreamUtil.toByteArray(in));
@@ -27,7 +28,7 @@ public abstract class Climate extends AbstractBuiltinDataset implements IntToDou
             out[i++] = buf.readFloat();
         }
         return out;
-    });
+    }, ReferenceStrength.SOFT);
 
     protected final double[] data = DATA_CACHE.get();
 

--- a/src/main/java/net/buildtheearth/terraplusplus/dataset/builtin/Soil.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/dataset/builtin/Soil.java
@@ -6,7 +6,8 @@ import io.netty.buffer.Unpooled;
 import net.buildtheearth.terraplusplus.util.RLEByteArray;
 import net.daporkchop.lib.binary.oio.StreamUtil;
 import net.daporkchop.lib.common.function.io.IOSupplier;
-import net.daporkchop.lib.common.ref.Ref;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 
 import java.io.InputStream;
 
@@ -16,7 +17,7 @@ public class Soil extends AbstractBuiltinDataset {
     protected static final int COLS = 10800;
     protected static final int ROWS = 5400;
 
-    private static final Ref<RLEByteArray> DATA_CACHE = Ref.soft((IOSupplier<RLEByteArray>) () -> {
+    private static final Cached<RLEByteArray> DATA_CACHE = Cached.global((IOSupplier<RLEByteArray>) () -> {
         ByteBuf buf;
         try (InputStream in = new LzmaInputStream(Climate.class.getResourceAsStream("soil.lzma"))) {
             buf = Unpooled.wrappedBuffer(StreamUtil.toByteArray(in));
@@ -27,7 +28,7 @@ public class Soil extends AbstractBuiltinDataset {
             builder.append(buf.getByte(i));
         }
         return builder.build();
-    });
+    }, ReferenceStrength.SOFT);
 
     private final RLEByteArray data = DATA_CACHE.get();
 

--- a/src/main/java/net/buildtheearth/terraplusplus/generator/CachedChunkData.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/generator/CachedChunkData.java
@@ -8,8 +8,8 @@ import lombok.NonNull;
 import lombok.Setter;
 import net.buildtheearth.terraplusplus.util.CustomAttributeContainer;
 import net.buildtheearth.terraplusplus.util.ImmutableCompactArray;
-import net.daporkchop.lib.common.ref.Ref;
-import net.daporkchop.lib.common.ref.ThreadRef;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 import net.daporkchop.lib.common.util.PorkUtil;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Biomes;
@@ -36,7 +36,7 @@ public class CachedChunkData extends CustomAttributeContainer {
     public static final int WATERDEPTH_TYPE_WATER = (byte) 0x00;
     public static final int WATERDEPTH_TYPE_OCEAN = (byte) 0x40;
 
-    private static final Ref<Builder> BUILDER_CACHE = ThreadRef.soft(Builder::new);
+    private static final Cached<Builder> BUILDER_CACHE = Cached.threadLocal(Builder::new, ReferenceStrength.SOFT);
 
     public static Builder builder() {
         return BUILDER_CACHE.get().reset();

--- a/src/main/java/net/buildtheearth/terraplusplus/generator/ChunkBiomesBuilder.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/generator/ChunkBiomesBuilder.java
@@ -2,8 +2,8 @@ package net.buildtheearth.terraplusplus.generator;
 
 import lombok.Getter;
 import net.buildtheearth.terraplusplus.util.ImmutableCompactArray;
-import net.daporkchop.lib.common.ref.Ref;
-import net.daporkchop.lib.common.ref.ThreadRef;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 import net.minecraft.world.biome.Biome;
 
 import java.util.Arrays;
@@ -15,7 +15,7 @@ import java.util.Arrays;
  */
 @Getter
 public class ChunkBiomesBuilder implements IEarthAsyncDataBuilder<ImmutableCompactArray<Biome>> {
-    private static final Ref<ChunkBiomesBuilder> BUILDER_CACHE = ThreadRef.soft(ChunkBiomesBuilder::new);
+    private static final Cached<ChunkBiomesBuilder> BUILDER_CACHE = Cached.threadLocal(ChunkBiomesBuilder::new, ReferenceStrength.SOFT);
 
     public static ChunkBiomesBuilder get() {
         return BUILDER_CACHE.get().reset();

--- a/src/main/java/net/buildtheearth/terraplusplus/generator/EarthGeneratorSettings.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/generator/EarthGeneratorSettings.java
@@ -39,8 +39,8 @@ import net.buildtheearth.terraplusplus.projection.transform.ProjectionTransform;
 import net.buildtheearth.terraplusplus.projection.transform.ScaleProjectionTransform;
 import net.buildtheearth.terraplusplus.projection.transform.SwapAxesProjectionTransform;
 import net.daporkchop.lib.binary.oio.StreamUtil;
-import net.daporkchop.lib.common.ref.Ref;
-import net.minecraft.world.biome.BiomeProvider;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 
@@ -131,8 +131,8 @@ public class EarthGeneratorSettings {
     @Getter(onMethod_ = { @JsonGetter })
     protected final boolean useDefaultTreeCover;
 
-    protected transient final Ref<EarthBiomeProvider> biomeProvider = Ref.soft(() -> new EarthBiomeProvider(this));
-    protected transient final Ref<CustomGeneratorSettings> customCubic = Ref.soft(() -> {
+    protected transient final Cached<EarthBiomeProvider> biomeProvider = Cached.global(() -> new EarthBiomeProvider(this), ReferenceStrength.SOFT);
+    protected transient final Cached<CustomGeneratorSettings> customCubic = Cached.global(() -> {
         CustomGeneratorSettings cfg;
         if (this.cwg().isEmpty()) { //use new minimal defaults
             cfg = new CustomGeneratorSettings();
@@ -150,8 +150,8 @@ public class EarthGeneratorSettings {
         }
         cfg.waterLevel = 0;
         return cfg;
-    });
-    protected transient final Ref<GeneratorDatasets> datasets = Ref.soft(() -> new GeneratorDatasets(this));
+    }, ReferenceStrength.SOFT);
+    protected transient final Cached<GeneratorDatasets> datasets = Cached.global(() -> new GeneratorDatasets(this), ReferenceStrength.SOFT);
 
     @Getter
     protected transient final Set<PopulateChunkEvent.Populate.EventType> skipChunkPopulation;

--- a/src/main/java/net/buildtheearth/terraplusplus/generator/populate/TreePopulator.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/generator/populate/TreePopulator.java
@@ -7,8 +7,8 @@ import io.github.opencubicchunks.cubicchunks.api.world.ICubicWorld;
 import net.buildtheearth.terraplusplus.generator.CachedChunkData;
 import net.buildtheearth.terraplusplus.generator.EarthGeneratorPipelines;
 import net.buildtheearth.terraplusplus.generator.data.TreeCoverBaker;
-import net.daporkchop.lib.common.ref.Ref;
-import net.daporkchop.lib.common.ref.ThreadRef;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -31,7 +31,7 @@ public class TreePopulator implements IEarthPopulator {
             Blocks.SNOW,
             Blocks.MYCELIUM);
 
-    protected static final Ref<byte[]> RNG_CACHE = ThreadRef.soft(() -> new byte[(ICube.SIZE >> 1) * (ICube.SIZE >> 1)]);
+    protected static final Cached<byte[]> RNG_CACHE = Cached.threadLocal(() -> new byte[(ICube.SIZE >> 1) * (ICube.SIZE >> 1)], ReferenceStrength.SOFT);
 
     @Override
     public void populate(World world, Random random, CubePos pos, Biome biome, CachedChunkData[] datas) {

--- a/src/main/java/net/buildtheearth/terraplusplus/projection/dymaxion/ConformalDynmaxionProjection.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/projection/dymaxion/ConformalDynmaxionProjection.java
@@ -7,7 +7,8 @@ import io.netty.buffer.Unpooled;
 import net.buildtheearth.terraplusplus.util.MathUtils;
 import net.daporkchop.lib.binary.oio.StreamUtil;
 import net.daporkchop.lib.common.function.io.IOSupplier;
-import net.daporkchop.lib.common.ref.Ref;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 import net.daporkchop.lib.common.util.PArrays;
 
 import java.io.InputStream;
@@ -23,9 +24,9 @@ public class ConformalDynmaxionProjection extends DymaxionProjection {
     protected static final double VECTOR_SCALE_FACTOR = 1.0d / 1.1473979730192934d;
     protected static final int SIDE_LENGTH = 256;
 
-    protected static final Ref<InvertableVectorField> INVERSE_CACHE = Ref.soft((IOSupplier<InvertableVectorField>) () -> {
-        double[][] vx = PArrays.filled(SIDE_LENGTH + 1, double[][]::new, i -> new double[SIDE_LENGTH + 1 - i]);
-        double[][] vy = PArrays.filled(SIDE_LENGTH + 1, double[][]::new, i -> new double[SIDE_LENGTH + 1 - i]);
+    protected static final Cached<InvertableVectorField> INVERSE_CACHE = Cached.global((IOSupplier<InvertableVectorField>) () -> {
+        double[][] vx = PArrays.filledBy(SIDE_LENGTH + 1, double[][]::new, i -> new double[SIDE_LENGTH + 1 - i]);
+        double[][] vy = PArrays.filledBy(SIDE_LENGTH + 1, double[][]::new, i -> new double[SIDE_LENGTH + 1 - i]);
 
         ByteBuf buf;
         try (InputStream in = new LzmaInputStream(ConformalDynmaxionProjection.class.getResourceAsStream("conformal.lzma"))) {
@@ -40,7 +41,7 @@ public class ConformalDynmaxionProjection extends DymaxionProjection {
         }
 
         return new InvertableVectorField(vx, vy);
-    });
+    }, ReferenceStrength.SOFT);
 
     protected final InvertableVectorField inverse = INVERSE_CACHE.get();
 

--- a/src/main/java/net/buildtheearth/terraplusplus/util/bvh/QuadtreeBVH.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/util/bvh/QuadtreeBVH.java
@@ -3,8 +3,8 @@ package net.buildtheearth.terraplusplus.util.bvh;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
-import net.daporkchop.lib.common.ref.Ref;
-import net.daporkchop.lib.common.ref.ThreadRef;
+import net.daporkchop.lib.common.reference.ReferenceStrength;
+import net.daporkchop.lib.common.reference.cache.Cached;
 
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
@@ -35,7 +35,7 @@ final class QuadtreeBVH<V extends Bounds2d> implements BVH<V> {
      */
     protected static final double MIN_LEAF_SIZE = 16.0d;
 
-    protected static final Ref<ArrayDeque<ArrayDeque<?>>> STACK_CACHE = ThreadRef.soft(ArrayDeque::new);
+    protected static final Cached<ArrayDeque<ArrayDeque<?>>> STACK_CACHE = Cached.threadLocal(ArrayDeque::new, ReferenceStrength.SOFT);
 
     @Getter(AccessLevel.NONE)
     protected final Node<V> root;

--- a/src/main/java/net/buildtheearth/terraplusplus/util/http/Http.java
+++ b/src/main/java/net/buildtheearth/terraplusplus/util/http/Http.java
@@ -28,8 +28,7 @@ import net.buildtheearth.terraplusplus.TerraConfig;
 import net.buildtheearth.terraplusplus.TerraMod;
 import net.daporkchop.lib.common.function.throwing.EFunction;
 import net.daporkchop.lib.common.misc.threadfactory.PThreadFactories;
-import net.daporkchop.lib.common.ref.Ref;
-import net.daporkchop.lib.common.ref.ThreadRef;
+import net.daporkchop.lib.common.reference.cache.Cached;
 
 import javax.net.ssl.SSLException;
 import java.net.MalformedURLException;
@@ -76,7 +75,7 @@ public class Http {
 
     protected final int MAX_CONTENT_LENGTH = Integer.MAX_VALUE; //impossibly large, no requests will actually be this big but whatever
 
-    protected static final Ref<Matcher> URL_FORMATTING_MATCHER_CACHE = ThreadRef.regex(Pattern.compile("\\$\\{([a-z0-9.]+)}"));
+    protected static final Cached<Matcher> URL_FORMATTING_MATCHER_CACHE = Cached.regex(Pattern.compile("\\$\\{([a-z0-9.]+)}"));
 
     static {
         try {


### PR DESCRIPTION
I mostly doing this because it benefits Terra-- by helping it run on modern Java versions, but it can benefit Terra++ as well so why not.